### PR TITLE
add default_auto_field

### DIFF
--- a/eventlog/apps.py
+++ b/eventlog/apps.py
@@ -8,6 +8,7 @@ from django.utils.translation import gettext_lazy as _
 class EventLogConfig(AppConfig):
     name = "eventlog"
     verbose_name = "EventLog"
+    default_auto_field = "django.db.models.AutoField"
 
     # List of event types to be used in events. A list of dictionaries
     # in the format::


### PR DESCRIPTION
This PR addressed Django's change in 3.2 from AutoField to BigAutoField.  With this set, no additional migration will be created regardless of Django version.

https://github.com/bartTC/django-eventlog/issues/11